### PR TITLE
Added 'test' target to build.

### DIFF
--- a/RobotFramework/build.xml
+++ b/RobotFramework/build.xml
@@ -96,4 +96,60 @@
     For more information on using ant, see http://ant.apache.org.
 
     -->
+    
+    <!-- ************ START FRC4931 MODIFICATION ************ -->
+    <!-- Define some properties that we'll use -->
+    <property name="extra.libs.dir" value="../libs"/>
+    <property name="test.src.dir" value="testsrc"/>
+    <property name="test.output.dir" value="tests"/>
+    <property name="test.report.dir" value="${test.output.dir}/report"/>
+    <property name="test.target.dir" value="${test.output.dir}/classes"/>
+    <!-- Define the classpath for compiling and running the unit tests; this includes our classes (after they are compiled) -->
+    <path id="junit.class.path">
+        <pathelement location="${extra.libs.dir}/junit-4.11.jar" /> 
+        <pathelement location="${extra.libs.dir}/hamcrest-core-1.3.jar" />
+        <pathelement location="${extra.libs.dir}/fest-util-1.1.6.jar" />
+        <pathelement location="${extra.libs.dir}/fest-assert-1.4.jar" />
+        <pathelement location="${build.dir}" />
+    </path>
+    <!-- Deletes the directories used by the tests-->
+    <target name="-post-clean">
+        <echo>Cleaning up test output</echo>
+        <delete dir="${test.output.dir}" />
+    </target>
+    <!-- Run the JUnit Tests -->
+    <target name="test" depends="clean, compile">
+        <!-- Could break each group of commands into separate targets, but this is cleaner for something so simple -->
+        <!-- Creates the directories used in the tests -->
+        <mkdir dir="${test.output.dir}" />
+        <mkdir dir="${test.target.dir}" />
+        <mkdir dir="${test.report.dir}" />
+        <!-- Compiles the java test code --> 
+        <echo>Compiling unit tests...</echo>
+        <javac srcdir="${test.src.dir}" destdir="${test.target.dir}" includeantruntime="false">
+          <classpath refid="junit.class.path" />
+        </javac> 
+        <echo>Running all unit tests...</echo>
+        <junit printsummary="off" showOutput="false" fork="true" haltonfailure="false">
+            <classpath refid="junit.class.path" />
+            <classpath> 
+                <pathelement location="${test.target.dir}"/>
+            </classpath>
+        <formatter type="plain" usefile="false" /> <!-- to screen -->
+            <batchtest todir="${test.report.dir}">
+                <fileset dir="${test.src.dir}">
+                    <include name="**/*Test*.java" />
+                </fileset>
+            </batchtest>
+        </junit>
+    </target>
+
+    <!-- Create a post-suite operation that will copy our extra libs -->
+    <target name="-post-suite">
+        <!-- IT'S NOT CLEAR THAT THIS WORKS AND WILL ACTUALLY GET DEPLOYED -->
+        <move  verbose="false" file="${extra.libs.dir}/junit-4.11.jar" todir="${suite.dir}"/>
+    </target>
+
+    <!-- ************ END FRC4931 MODIFICATION ************ -->
+    
 </project>


### PR DESCRIPTION
This section of the `build.xml` file adds in the ability to use this command:

    $ ant test

to automatically run all of the unit tests within the project. The test classes exist in a different source folder, and are compiled into a different output folder than the regular classes that would go on the robot.  BTW, the regular `ant clean` will also clean up the class files for the tests, too.

Note that it's not clear whether this will work with the 2015 Eclipse plugin. But it's probably close; it just depends on how much they changed the ant-based build system to make it work better with the new plugin.

One more thing. It's not currently possible to use the Ant-based build scripts with the new Java 8 codebase, since the Ant-based build for the 2014 cRIO will force the 'source' and 'target' options of the compiler to 1.4 and 1.3, respectively. I'm not sure it's a problem now, since for now we can just compile and run the tests from within Eclipse, and we won't need the Ant-based build until we want to start deploying the code to the RoboRIO.