### PR TITLE
Accelerometer Interface

### DIFF
--- a/RobotFramework/src/org/frc4931/robot/component/Accelerometer.java
+++ b/RobotFramework/src/org/frc4931/robot/component/Accelerometer.java
@@ -1,0 +1,44 @@
+/*
+ * FRC 4931 (http://www.evilletech.com)
+ *
+ * Open source software. Licensed under the FIRST BSD license file in the
+ * root directory of this project's Git repository.
+ */
+package org.frc4931.robot.component;
+
+import org.frc4931.utils.Triple;
+
+/**
+ * An accelerometer is a device capable of sensing acceleration. By performing
+ * two integrations, an accelerometer can also find velocity and displacement.
+ * 
+ * @author Zach Anderson
+ */
+public interface Accelerometer {
+    
+    /**
+     * Gets the acceleration on all three axis of this {@link Accelerometer}.
+     * @return a {@link Triple} containing all three axis of acceleration
+     */
+    public Triple getAcceleration();
+    
+    /**
+     * Gets the velocity on all three axis of this {@link Accelerometer},
+     * found by integrating the acceleration with respect to time.
+     * @return a {@link Triple} containing all three axis of velocity
+     */
+    public Triple getVelocity();
+    
+    /**
+     * Gets the displacement on all three axis of this {@link Accelerometer},
+     * found by integrating the velocity with respect to time.
+     * @return a {@link Triple} containing all three axis of displacement
+     */
+    public Triple getDisplacement();
+    
+    /**
+     * Updates the current acceleration of this {@link Accelerometer} and
+     * performs the integrations to find velocity and displacement.
+     */
+    public void update();
+}

--- a/RobotFramework/src/org/frc4931/robot/component/LimitedMotor.java
+++ b/RobotFramework/src/org/frc4931/robot/component/LimitedMotor.java
@@ -6,6 +6,7 @@
  */
 package org.frc4931.robot.component;
 
+import org.frc4931.robot.component.Motor.Direction;
 import org.frc4931.robot.hardware.Hardware.Sensors.Switches;
 
 /**
@@ -113,7 +114,8 @@ public final class LimitedMotor {
      * Gets the direction the underlying {@link Motor} is turning. Can be
      * {@code FORWARD}, {@code REVERSE}, or {@code STOPPED}.
      * 
-     * @return
+     * @return a {@link Direction} representing the current direction of this
+     * {@link LimitedMotor}.
      */
     public Motor.Direction getDirection() {
         return motor.getDirection();

--- a/RobotFramework/src/org/frc4931/robot/hardware/Hardware.java
+++ b/RobotFramework/src/org/frc4931/robot/hardware/Hardware.java
@@ -6,6 +6,7 @@
  */
 package org.frc4931.robot.hardware;
 
+import org.frc4931.robot.component.Accelerometer;
 import org.frc4931.robot.component.DistanceSensor;
 import org.frc4931.robot.component.Gyroscope;
 import org.frc4931.robot.component.Motor;
@@ -39,7 +40,41 @@ public class Hardware {
         public static Gyroscope gyroscope(int channel) {
             return new HardwareGyroscope(channel);
         }
-
+        
+        public static final class Accelerometers {
+            /**
+             * Create a new {@link Accelerometer} with a range of +-2g's
+             * @return an {@link Accelerometer}
+             */
+            public static Accelerometer accelerometer2G() {
+                return new HardwareAccelerometer(2);
+            }
+            
+            /**
+             * Create a new {@link Accelerometer} with a range of +-4g's
+             * @return an {@link Accelerometer}
+             */
+            public static Accelerometer accelerometer4G() {
+                return new HardwareAccelerometer(4);
+            }
+            
+            /**
+             * Create a new {@link Accelerometer} with a range of +-8g's
+             * @return an {@link Accelerometer}
+             */
+            public static Accelerometer accelerometer8G() {
+                return new HardwareAccelerometer(8);
+            }
+        
+            /**
+            * Create a new {@link Accelerometer} with a range of +-16g's
+            * @return an {@link Accelerometer}
+            */
+            public static Accelerometer accelerometer16G() {
+                return new HardwareAccelerometer(16);
+            }
+        }
+        
         public static final class Switches {
             /**
              * Create a generic normally closed switch on the specified channel.

--- a/RobotFramework/src/org/frc4931/robot/hardware/HardwareAccelerometer.java
+++ b/RobotFramework/src/org/frc4931/robot/hardware/HardwareAccelerometer.java
@@ -1,0 +1,86 @@
+/*
+ * FRC 4931 (http://www.evilletech.com)
+ *
+ * Open source software. Licensed under the FIRST BSD license file in the
+ * root directory of this project's Git repository.
+ */
+package org.frc4931.robot.hardware;
+
+import org.frc4931.robot.component.Accelerometer;
+import org.frc4931.utils.Triple;
+
+import edu.wpi.first.wpilibj.ADXL345_I2C;
+import edu.wpi.first.wpilibj.ADXL345_I2C.AllAxes;
+
+/**
+ * Wrapper for the WPILib {@link ADXL345_I2C}.
+ * 
+ * @author Zach Anderson
+ */
+final class HardwareAccelerometer implements Accelerometer{
+    private final ADXL345_I2C accel;
+    
+    private long lastUpdate = 0;
+    
+    private double xAccel;
+    private double yAccel;
+    private double zAccel;
+    
+    private double xVel;
+    private double yVel;
+    private double zVel;
+    
+    private double xDisp;
+    private double yDisp;
+    private double zDisp;
+    
+    public HardwareAccelerometer(int range) {
+        if(range==2)
+            accel = new ADXL345_I2C(0, ADXL345_I2C.DataFormat_Range.k2G);
+        else if(range==4)
+            accel = new ADXL345_I2C(0, ADXL345_I2C.DataFormat_Range.k4G);
+        else if(range==8)
+            accel = new ADXL345_I2C(0, ADXL345_I2C.DataFormat_Range.k8G);
+        else{
+            assert range == 16;
+            accel = new ADXL345_I2C(0, ADXL345_I2C.DataFormat_Range.k16G);
+        }
+    }
+    
+    @Override
+    public Triple getAcceleration() {
+        return new Triple(xAccel,yAccel,zAccel);
+    }
+
+    @Override
+    public Triple getVelocity() {
+        return new Triple(xVel,yVel,zVel);
+    }
+
+    @Override
+    public Triple getDisplacement() {
+        return new Triple(xDisp,yDisp,zDisp);
+    }
+
+    @Override
+    public void update() {
+        long now = System.nanoTime();
+        long delta = now-lastUpdate;
+        
+        double d = delta/1.0e-9;
+        
+        AllAxes a = accel.getAccelerations();
+        
+        xAccel = a.XAxis;
+        yAccel = a.YAxis;
+        zAccel = a.ZAxis;
+        
+        xVel += xAccel*d;
+        yVel += yAccel*d;
+        zVel += zAccel*d;
+        
+        xDisp += xVel*d;
+        yDisp += yVel*d;
+        zDisp += zVel*d;
+    }
+}

--- a/RobotFramework/src/org/frc4931/robot/hardware/HardwareDigitalUltrasonic.java
+++ b/RobotFramework/src/org/frc4931/robot/hardware/HardwareDigitalUltrasonic.java
@@ -24,7 +24,7 @@ import edu.wpi.first.wpilibj.Ultrasonic;
  * 
  * @author Zach Anderson
  * @see DistanceSensor
- * @see Hardwear
+ * @see Hardware
  * @see edu.wpi.first.wpilibj.Ultrasonic
  */
 final class HardwareDigitalUltrasonic implements DistanceSensor {

--- a/RobotFramework/src/org/frc4931/robot/hardware/HardwareGyroscope.java
+++ b/RobotFramework/src/org/frc4931/robot/hardware/HardwareGyroscope.java
@@ -12,11 +12,11 @@ import edu.wpi.first.wpilibj.Gyro;
 
 /**
  * Wrapper for WPILib {@link Gyro}. Should be constructed by
- * {@link Hardware#gyroscope(int)}.
+ * {@link Hardware.Sensors#gyroscope(int)}.
  * 
  * @author Zach Anderson
  * @see Gyroscope
- * @see Hardwear
+ * @see Hardware
  * @see edu.wpi.first.wpilibj.Gyro
  */
 final class HardwareGyroscope implements Gyroscope {

--- a/RobotFramework/src/org/frc4931/robot/hardware/HardwareMotor.java
+++ b/RobotFramework/src/org/frc4931/robot/hardware/HardwareMotor.java
@@ -25,6 +25,7 @@ public final class HardwareMotor implements Motor {
         this.controller = controller;
     }
 
+    @Override
     public void setSpeed(double speed) {
         controller.set(validateSpeed(speed));
     }
@@ -44,6 +45,7 @@ public final class HardwareMotor implements Motor {
         return speed;
     }
 
+    @Override
     public double getSpeed() {
         return controller.get();
     }

--- a/RobotFramework/src/org/frc4931/utils/Triple.java
+++ b/RobotFramework/src/org/frc4931/utils/Triple.java
@@ -1,0 +1,33 @@
+/*
+ * FRC 4931 (http://www.evilletech.com)
+ *
+ * Open source software. Licensed under the FIRST BSD license file in the
+ * root directory of this project's Git repository.
+ */
+package org.frc4931.utils;
+
+/**
+ * Simple class for storing and accessing three doubles.
+ * 
+ * @author Zach Anderson
+ */
+public class Triple {
+    private final double x;
+    private final double y;
+    private final double z;
+    
+    public Triple(double x, double y, double z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+    public double getX() {
+        return x;
+    }
+    public double getY() {
+        return y;
+    }
+    public double getZ() {
+        return z;
+    }
+}

--- a/RobotFramework/testsrc/org/frc4931/robot/component/mock/MockAccelerometer.java
+++ b/RobotFramework/testsrc/org/frc4931/robot/component/mock/MockAccelerometer.java
@@ -1,0 +1,63 @@
+/*
+ * FRC 4931 (http://www.evilletech.com)
+ *
+ * Open source software. Licensed under the FIRST BSD license file in the
+ * root directory of this project's Git repository.
+ */
+package org.frc4931.robot.component.mock;
+
+import org.frc4931.robot.component.Accelerometer;
+import org.frc4931.utils.Triple;
+
+/**
+ * A test implementation of {@link Accelerometer} that does not
+ * require any hardware to use.
+ * 
+ * @author Zach Anderson
+ */
+public class MockAccelerometer implements Accelerometer{
+    private double xAccel;
+    private double yAccel;
+    private double zAccel;
+    
+    private double xVel;
+    private double yVel;
+    private double zVel;
+    
+    private double xDisp;
+    private double yDisp;
+    private double zDisp;
+    
+    public void setAcceleration(double x, double y, double z){
+        xAccel = x;
+        yAccel = y;
+        zAccel = z;
+    }
+    public void setVelocity(double x, double y, double z){
+        xVel = x;
+        yVel = y;
+        zVel = z;
+    }
+    public void setDisplacement(double x, double y, double z){
+        xDisp = x;
+        yDisp = y;
+        zDisp = z;
+    }
+    @Override
+    public Triple getAcceleration() {
+        return new Triple(xAccel, yAccel, zAccel);
+    }
+
+    @Override
+    public Triple getVelocity() {
+        return new Triple(xVel, yVel, zVel);
+    }
+
+    @Override
+    public Triple getDisplacement() {
+        return new Triple(xDisp, yDisp, zDisp);
+    }
+
+    @Override
+    public void update() { }
+}

--- a/RobotFramework/testsrc/org/frc4931/robot/component/mock/MockMotor.java
+++ b/RobotFramework/testsrc/org/frc4931/robot/component/mock/MockMotor.java
@@ -44,6 +44,7 @@ public class MockMotor implements Motor {
         this.speed = speed;
     }
 
+    @Override
     public void setSpeed(double speed) {
         this.speed = speed;
     }


### PR DESCRIPTION
Adds an interface for a three axis accelerometer.  We don't actually know how to access the RoboRio oboard accelerometer yet, so this provides an implementation to use the same kind of gyroscope we did last year.  When we get our hands on a RoboRio, we'll have to create another implementation for it.